### PR TITLE
Create pyzabbix-verify_ssl

### DIFF
--- a/pyzabbix-verify_ssl
+++ b/pyzabbix-verify_ssl
@@ -1,0 +1,1 @@
+Adding new verify_ssl feature


### PR DESCRIPTION
I've added the ability to disable verification of ssl via 'verify_ssl' parameter in the ZabbixAPI constructor.
The default remains to verify. Seems like a reasonable thing to add.
