### PR TITLE
New feature: Ability to disable verification of ssl via 'verify_ssl' parameter to ZabbixAPI constructor.

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -29,6 +29,7 @@ class ZabbixAPI(object):
                  server='http://localhost/zabbix',
                  session=None,
                  verify_ssl=True):
+
         self.verify_ssl = verify_ssl
 
         if session:


### PR DESCRIPTION
The defaults remains to verify, and the parameter is optional so existing scripts will be unaffected.
