### PR TITLE
Allow no SSL certificate verify as param

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -27,12 +27,17 @@ class AlreadyExists(ZabbixAPIException):
 class ZabbixAPI(object):
     def __init__(self,
                  server='http://localhost/zabbix',
-                 session=None):
+                 session=None,
+                 ssl_verify=True):
 
         if session:
             self.session = session
         else:
             self.session = requests.Session()
+
+        # Allow no SSL verification - else default to requests.session's default
+        if not ssl_verify:
+            self.session.verify = False        
 
         # Default headers for all requests
         self.session.headers.update({


### PR DESCRIPTION
Just a conveniency to let non valid SSL certs (either because self-signed or wildcard) to go along without providing a full `session` object in the args.

I'm not sure what is the original purpose of allowing `session` to be passed as arg to the instantiation of the `ZabbixAPI` class, so it may duplicate its use.

I agree we could simply use the following code:

``` python
from requests import Session
from pyzabbix import ZabbixAPI
s = Session()
s.verify = False
zapi = ZabbixAPI(server='https://my.zabbix.com', session=s)
```

But I believe it's somehow simpler to just go with:

``` python
from pyzabbix import ZabbixAPI
zapi = ZabbixAPI(server='https://my.zabbix.com', ssl_verify=False)
```

I let it to your best judgement :)
