### PR TITLE
Allow users to use pure dictionary for param.

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -137,10 +137,13 @@ class ZabbixAPIObjectClass(object):
         def fn(*args, **kwargs):
             if args and kwargs:
                 raise TypeError("Found both args and kwargs")
-
+            if args and len(args) == 1 and type(args[0]) == dict:
+                req_args = args[0]
+            else:
+                req_args = args or kwargs
             return self.parent.do_request(
                 '{0}.{1}'.format(self.name, attr),
-                args or kwargs
+                req_args
             )['result']
 
         return fn


### PR DESCRIPTION
PyZabbix allows this kind of arguments:

result = zapi.host.get(output'='extend',
                       filter={'host': host})

This is useful enough, while sometimes it will be
more helpful if it accepts a dict.

E.g.

result = zapi.host.get({'output': 'extend',
                        'filter': {'host': host}})

Current implementation does accept this style
but it will be parsed as a tuple containing the
dict, so Zabbix API will just ignores that part.

PyZabbix's log will show something like this:

Sending: {'params': ({'filter': {'host': 'mugi.in.mokha.co.jp'},
'output': 'extend'},), 'jsonrpc': '2.0', 'method': 'host.get', 'auth':
'68ba....636303', 'id': 2}

This change will remove the tuple part only when it is sure
the content is a single dict.
