### PR TITLE
Allows do_request to accept json

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 import json
-
+import types
 
 class _NullHandler(logging.Handler):
     def emit(self, record):
@@ -80,6 +80,9 @@ class ZabbixAPI(object):
         return self.apiinfo.version()
 
     def do_request(self, method, params=None):
+        if ( type(params) is types.TupleType):
+            if ( type(params[0]) is types.DictType):
+                params = params[0]
         request_json = {
             'jsonrpc': '2.0',
             'method': method,


### PR DESCRIPTION
This mod allow users to switch from zabbix_api to pyzabbix without any code change at all.

Without it, they would be required to change all of their requests.

Eg.
With zabbix_api:
```python
query = {"output": ["host"]}
proxies = zapi.proxy.get(query)
```

With pyzabbix 0.7.2:
```python
proxies = zapi.proxy.get(output=["host"])
```

With this patched pyzabbix:
Either of both cases above will work.
```python
query = {"output": ["host"]}
proxies = zapi.proxy.get(query)

proxies = zapi.proxy.get(output=["host"])
```

This change is better perceived when doing a loop call of some sort and you want to change / add / remove something on the fly from your query:
```python
some_list = [
    {"description": some_var, "something_else": 1 },
    {"description": another_var, "something_else": 2 }
]
for x in some_list:
    query = {
        "description": x['description']
        ...
    }
    zapi.host.update(query)
    if x['something_else'] == 1:
        query['proxyid'] = some_var
    zapi.host.update(query)
```