### PR TITLE
workaround for ZBX-9340

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -122,6 +122,8 @@ class ZabbixAPI(object):
         self.id += 1
 
         if 'error' in response_json:  # some exception
+            if 'data' not in response_json['error']: # some errors don't contain 'data': workaround for ZBX-9340
+                response_json['error']['data'] = "No data"
             msg = "Error {code}: {message}, {data} while sending {json}".format(
                 code=response_json['error']['code'],
                 message=response_json['error']['message'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pyzabbix",
-    version="0.7.2",
+    version="0.7.3",
     install_requires=[
         "requests>=1.0",
     ],


### PR DESCRIPTION
some error messages (database down) don't contain 'data' attribute, in this case, we add the 'data' attribute otherwise an exception will be raised. The bug will be fixed by Zabbix but of course a lot of time will pass before everybody updates their Zabbix frontend, so in the meantime, we gracefully deal with the missing attribute by adding it only if it's missing, with the "No data" value.