### PR TITLE
Fixed issue with self.auth being blank and not null, causing API fail…

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -46,7 +46,7 @@ class ZabbixAPI(object):
         })
 
         self.use_authenticate = use_authenticate
-        self.auth = ''
+        self.auth = None
         self.id = 0
 
         self.timeout = timeout


### PR DESCRIPTION
There's an issue talking to the 2.4 API's - self.auth = '' causes the json to actually send a blank instead of a null, causing auth failures.  setting self.auth = None fixes this.