### PR TITLE
Added no-cache option for API-calls

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -42,7 +42,8 @@ class ZabbixAPI(object):
         # Default headers for all requests
         self.session.headers.update({
             'Content-Type': 'application/json-rpc',
-            'User-Agent': 'python/pyzabbix'
+            'User-Agent': 'python/pyzabbix',
+            'Cache-Control': 'no-cache'
         })
 
         self.use_authenticate = use_authenticate


### PR DESCRIPTION
When accessing the zabbix api via a proxy (set by environment) the results may get cached depending on the proxy. This fix should prevent that.