### PR TITLE
Fix error message when request contains utf-8 data

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -125,7 +125,7 @@ class ZabbixAPI(object):
         if 'error' in response_json:  # some exception
             if 'data' not in response_json['error']: # some errors don't contain 'data': workaround for ZBX-9340
                 response_json['error']['data'] = "No data"
-            msg = "Error {code}: {message}, {data} while sending {json}".format(
+            msg = u"Error {code}: {message}, {data} while sending {json}".format(
                 code=response_json['error']['code'],
                 message=response_json['error']['message'],
                 data=response_json['error']['data'],


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/bin/zabbix-phone-creator", line 97, in <module>
    zapi.host.update(hostid=h[0]['hostid'], name=visible_hostname)
  File "/usr/local/lib/python2.7/dist-packages/pyzabbix/__init__.py", line 158, in fn
    args or kwargs
  File "/usr/local/lib/python2.7/dist-packages/pyzabbix/__init__.py", line 133, in do_request
    json=request_json
UnicodeEncodeError: 'ascii' codec can't encode characters in position 44-54: ordinal not in range(128)