### PR TITLE
allow user to disable ssl verification

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
+
 import logging
 import requests
 import json
 
+requests.packages.urllib3.disable_warnings()
 
 class _NullHandler(logging.Handler):
     def emit(self, record):
@@ -26,7 +28,8 @@ class ZabbixAPI(object):
                  server='http://localhost/zabbix',
                  session=None,
                  use_authenticate=False,
-                 timeout=None):
+                 timeout=None,
+                 verify=True):
         """
         Parameters:
             server: Base URI for zabbix web interface (omitting /api_jsonrpc.php)
@@ -50,6 +53,7 @@ class ZabbixAPI(object):
         self.use_authenticate = use_authenticate
         self.auth = ''
         self.id = 0
+        self.verify = verify
 
         self.timeout = timeout
 
@@ -100,7 +104,8 @@ class ZabbixAPI(object):
         response = self.session.post(
             self.url,
             data=json.dumps(request_json),
-            timeout=self.timeout
+            timeout=self.timeout,
+            verify=self.verify,
         )
         logger.debug("Response Code: %s", str(response.status_code))
 


### PR DESCRIPTION
Allow user to disable ssl verification

    from pyzabbix import ZabbixAPI
    import requests
    requests.packages.urllib3.disable_warnings()

    zapi = ZabbixAPI(server_url, verify=False)
