### PR TITLE
Equivlanets in other languages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -98,6 +98,11 @@ Response Body: {
 >>>
 ```
 
+## Equivalents in other lagnuages
+
+- R - [RZabbix](https://cran.r-project.org/web/packages/RZabbix/index.html)
+
+
 ## License ##
 LGPL 2.1   http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 


### PR DESCRIPTION
I am sharing a link from R equivalent to pyzabbix. https://github.com/MarcinKosinski/RZabbix/blob/master/README.md Maybe you would like to cross-link to R equivalent of pyzabbix ?