### PR TITLE
* Made python code PEP8 clean

### DIFF
--- a/examples/add_item.py
+++ b/examples/add_item.py
@@ -15,13 +15,13 @@ zapi.login('Admin', 'zabbix')
 
 host_name = 'example.com'
 
-hosts = zapi.host.get(filter={"host": host_name},selectInterfaces=["interfaceid"])
+hosts = zapi.host.get(filter={"host": host_name}, selectInterfaces=["interfaceid"])
 if hosts:
     host_id = hosts[0]["hostid"]
     print("Found host id {0}".format(host_id))
 
     try:
-        item=zapi.item.create(
+        item = zapi.item.create(
             hostid=host_id,
             name='Used disk space on $1 in %',
             key_='vfs.fs.size[/,pused]',
@@ -33,6 +33,6 @@ if hosts:
     except ZabbixAPIException as e:
         print(e)
         sys.exit()
-    print("Added item with itemid {0} to host: {1}".format(item["itemids"][0],host_name))
+    print("Added item with itemid {0} to host: {1}".format(item["itemids"][0], host_name))
 else:
     print("No hosts found")

--- a/examples/current_issues.py
+++ b/examples/current_issues.py
@@ -2,7 +2,6 @@
 Shows a list of all current issues (AKA tripped triggers)
 """
 
-from getpass import getpass
 from pyzabbix import ZabbixAPI
 
 # The hostname at which the Zabbix web interface is available
@@ -15,34 +14,33 @@ zapi.login('api_username', 'api_password')
 
 # Get a list of all issues (AKA tripped triggers)
 triggers = zapi.trigger.get(only_true=1,
-    skipDependent=1,
-    monitored=1,
-    active=1,
-    output='extend',
-    expandDescription=1,
-    expandData='host',
-)
+                            skipDependent=1,
+                            monitored=1,
+                            active=1,
+                            output='extend',
+                            expandDescription=1,
+                            expandData='host',
+                            )
 
 # Do another query to find out which issues are Unacknowledged
 unack_triggers = zapi.trigger.get(only_true=1,
-    skipDependent=1,
-    monitored=1,
-    active=1,
-    output='extend',
-    expandDescription=1,
-    expandData='host',
-    withLastEventUnacknowledged=1,
-)
+                                  skipDependent=1,
+                                  monitored=1,
+                                  active=1,
+                                  output='extend',
+                                  expandDescription=1,
+                                  expandData='host',
+                                  withLastEventUnacknowledged=1,
+                                  )
 unack_trigger_ids = [t['triggerid'] for t in unack_triggers]
 for t in triggers:
-    t['unacknowledged'] = True if t['triggerid'] in unack_trigger_ids\
-    else False
+    t['unacknowledged'] = True if t['triggerid'] in unack_trigger_ids \
+        else False
 
 # Print a list containing only "tripped" triggers
 for t in triggers:
     if int(t['value']) == 1:
-        print("{0} - {1} {2}".format(
-            t['host'],
-            t['description'],
-            '(Unack)' if t['unacknowledged'] else '')
-        )
+        print("{0} - {1} {2}".format(t['host'],
+                                     t['description'],
+                                     '(Unack)' if t['unacknowledged'] else '')
+              )

--- a/examples/fix_host_ips.py
+++ b/examples/fix_host_ips.py
@@ -7,7 +7,6 @@ and fixes it if required.
 """
 
 import socket
-from getpass import getpass
 from pyzabbix import ZabbixAPI, ZabbixAPIException
 
 # The hostname at which the Zabbix web interface is available
@@ -22,7 +21,7 @@ zapi.session.verify = False
 zapi.login('Admin', 'zabbix')
 
 # Loop through all hosts interfaces, getting only "main" interfaces of type "agent"
-for h in zapi.hostinterface.get(output=["dns","ip","useip"],selectHosts=["host"],filter={"main":1,"type":1}):
+for h in zapi.hostinterface.get(output=["dns", "ip", "useip"], selectHosts=["host"], filter={"main": 1, "type": 1}):
     # Make sure the hosts are named according to their FQDN
     if h['dns'] != h['hosts'][0]['host']:
         print('Warning: %s has dns "%s"' % (h['hosts'][0]['host'], h['dns']))

--- a/examples/history_data.py
+++ b/examples/history_data.py
@@ -22,23 +22,23 @@ time_from = time_till - 60 * 60 * 4  # 4 hours
 
 # Query item's history (integer) data
 history = zapi.history.get(itemids=[item_id],
-    time_from=time_from,
-    time_till=time_till,
-    output='extend',
-    limit='5000',
-)
+                           time_from=time_from,
+                           time_till=time_till,
+                           output='extend',
+                           limit='5000',
+                           )
 
 # If nothing was found, try getting it from history (float) data
 if not len(history):
     history = zapi.history.get(itemids=[item_id],
-        time_from=time_from,
-        time_till=time_till,
-        output='extend',
-        limit='5000',
-        history=0,
-    )
+                               time_from=time_from,
+                               time_till=time_till,
+                               output='extend',
+                               limit='5000',
+                               history=0,
+                               )
 
 # Print out each datapoint
 for point in history:
     print("{0}: {1}".format(datetime.fromtimestamp(int(point['clock']))
-    .strftime("%x %X"), point['value']))
+                            .strftime("%x %X"), point['value']))

--- a/examples/import_templates.py
+++ b/examples/import_templates.py
@@ -76,4 +76,4 @@ for file in files:
         try:
             zapi.confimport('xml', template, rules)
         except ZabbixAPIException as e:
-            print e
+            print(e)

--- a/examples/timeout.py
+++ b/examples/timeout.py
@@ -14,10 +14,10 @@ ZABBIX_SERVER = 'https://zabbix.example.com'
 TIMEOUT = 3.5
 
 # You can define the timeout while creating the ZabbixAPI object:
-zapi = ZabbixAPI(ZABBIX_SERVER,timeout=TIMEOUT)
+zapi = ZabbixAPI(ZABBIX_SERVER, timeout=TIMEOUT)
 
 # Login to the Zabbix API
 zapi.login('api_username', 'api_password')
 
 # Or you can re-define it after
-zapi.timeout=TIMEOUT
+zapi.timeout = TIMEOUT

--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -59,7 +59,10 @@ class ZabbixAPI(object):
     def login(self, user='', password=''):
         """Convenience method for calling user.authenticate and storing the resulting auth token
            for further commands.
-           If use_authenticate is set, it uses the older (Zabbix 1.8) authentication command"""
+           If use_authenticate is set, it uses the older (Zabbix 1.8) authentication command
+           :param password: Password used to login into Zabbix
+           :param user: Username used to login into Zabbix
+        """
 
         # If we have an invalid auth token, we are not allowed to send a login
         # request. Clear it before trying.
@@ -69,13 +72,17 @@ class ZabbixAPI(object):
         else:
             self.auth = self.user.login(user=user, password=password)
 
-    def confimport(self, format='', source='', rules=''):
+    def confimport(self, confformat='', source='', rules=''):
         """Alias for configuration.import because it clashes with
-           Python's import reserved keyword"""
+           Python's import reserved keyword
+           :param rules:
+           :param source:
+           :param confformat:
+        """
 
         return self.do_request(
             method="configuration.import",
-            params={"format": format, "source": source, "rules": rules}
+            params={"format": confformat, "source": source, "rules": rules}
         )['result']
 
     def api_version(self):
@@ -92,7 +99,6 @@ class ZabbixAPI(object):
         # We don't have to pass the auth token if asking for the apiinfo.version
         if self.auth and method != 'apiinfo.version':
             request_json['auth'] = self.auth
-
 
         logger.debug("Sending: %s", json.dumps(request_json,
                                                indent=4,
@@ -124,7 +130,7 @@ class ZabbixAPI(object):
         self.id += 1
 
         if 'error' in response_json:  # some exception
-            if 'data' not in response_json['error']: # some errors don't contain 'data': workaround for ZBX-9340
+            if 'data' not in response_json['error']:  # some errors don't contain 'data': workaround for ZBX-9340
                 response_json['error']['data'] = "No data"
             msg = "Error {code}: {message}, {data}".format(
                 code=response_json['error']['code'],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,4 +108,4 @@ class TestPyZabbix(unittest.TestCase):
         )
 
         # Check response
-        self.assertEqual(set(result["itemids"]), set(["22982", "22986"]))
+        self.assertEqual(set(result["itemids"]), {"22982", "22986"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,4 +108,4 @@ class TestPyZabbix(unittest.TestCase):
         )
 
         # Check response
-        self.assertEqual(set(result["itemids"]), {"22982", "22986"})
+        self.assertEqual(set(result["itemids"]), set(["22982", "22986"]))


### PR DESCRIPTION
That is:
* Add some spaces where recommended
* Set correct indentation for over-hanging parameters
* Remove unused imports
* Added docstring parameters (although a good description is still missing)
* rename shadowed parameter "format"
* fixed one error in the examples

I just cleaned it up, to have a nice version for myself.
Thought you might like it/want it, too.
For those who dont know what PEP8 is, see here https://www.python.org/dev/peps/pep-0008/