### PR TITLE
Add context manager to ZabbixAPI

### DIFF
--- a/examples/with_context.py
+++ b/examples/with_context.py
@@ -1,0 +1,14 @@
+"""
+Prints hostnames for all known hosts.
+"""
+
+from pyzabbix import ZabbixAPI
+
+ZABBIX_SERVER = 'https://zabbix.example.com'
+
+# Use context manager to auto-logout after request is done.
+with ZabbixAPI(ZABBIX_SERVER) as zapi:
+    zapi.login('api_username', 'api_password')
+    hosts = zapi.host.get(output=['name'])
+    for host in hosts:
+        print(host['name'])

--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -55,6 +55,15 @@ class ZabbixAPI(object):
         self.url = server + '/api_jsonrpc.php'
         logger.info("JSON-RPC Server Endpoint: %s", self.url)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        if isinstance(exception_value, (ZabbixAPIException, type(None))):
+            if self.check_authentication():
+                self.user.logout()
+            return True
+
     def login(self, user='', password=''):
         """Convenience method for calling user.authenticate and storing the resulting auth token
            for further commands.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,3 +109,21 @@ class TestPyZabbix(unittest.TestCase):
 
         # Check response
         self.assertEqual(set(result["itemids"]), set(["22982", "22986"]))
+
+
+    @httpretty.activate
+    def test_login_with_context(self):
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://example.com/api_jsonrpc.php",
+            body=json.dumps({
+                "jsonrpc": "2.0",
+                "result": "0424bd59b807674191e7d77572075f33",
+                "id": 0
+            }),
+        )
+
+        with ZabbixAPI('http://example.com') as zapi:
+            zapi.login('mylogin', 'mypass')
+            self.assertEqual(zapi.auth, "0424bd59b807674191e7d77572075f33")
+


### PR DESCRIPTION
Sometimes it's more readable to just use the _with_ statement than to logout the user manually.

Tested on Zabbix 4.0.