### PR TITLE
Fix README links to requests Python library

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,7 +33,7 @@ for h in zapi.host.get(output="extend"):
 Refer to the [Zabbix API Documentation](https://www.zabbix.com/documentation/3.0/manual/api/reference) and the [PyZabbix Examples](https://github.com/lukecyca/pyzabbix/tree/master/examples) for more information.
 
 ### Customizing the HTTP request
-PyZabbix uses the [requests](http://www.python-requests.org/en/latest/) library for http. You can customize the request parameters by configuring the [requests Session](http://docs.python-requests.org/en/latest/user/advanced/#session-objects) object used by PyZabbix.
+PyZabbix uses the [requests](https://requests.readthedocs.io/en/master/) library for HTTP. You can customize the request parameters by configuring the [requests Session](https://requests.readthedocs.io/en/master/user/advanced/#session-objects) object used by PyZabbix.
 
 This is useful for:
 * Customizing headers


### PR DESCRIPTION
Current links are broken. Looks like the requests docs got moved around.