### PR TITLE
Fix broken sdist: Add missing README.markdown

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.markdown


### PR DESCRIPTION
README.markdown needs to be included in the sdist (.tar.gz) release, or else setup.py will raise an error when trying to build the package due to the missing file.

Even better IMO would be to provide a universal, py2-py3 wheel if possible. That can be a next step.

Current result when installing `pyzabbix==0.8.1` under Py3:
```
$ pip install pyzabbix==0.8.1
Looking in indexes: https://<redacted private index>
Collecting pyzabbix==0.8.1
  Downloading https://<redacted private index>/pyzabbix-0.8.1.tar.gz (5.1 kB)
    ERROR: Command errored out with exit status 1:
     command: 'c:\users\vphilippon\tests\pyzabbix\venv\scripts\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'F:\\tmp\\pip-install-fzpk80yp\\pyzabbix\\setup.py'"'"'; __file__='"'"'F:\\tmp\\pip-install-fzpk80yp\\pyzabbix\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'F:\tmp\pip-pip-egg-info-dgsy6h5m'
         cwd: F:\tmp\pip-install-fzpk80yp\pyzabbix\
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "F:\tmp\pip-install-fzpk80yp\pyzabbix\setup.py", line 3, in <module>
        with open("README.markdown", "r") as fh:
    FileNotFoundError: [Errno 2] No such file or directory: 'README.markdown'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```