### PR TITLE
Add autodetecting of API version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     version="0.8.2",
     install_requires=[
         "requests>=1.0",
+        "semantic-version>=2.8"
     ],
     description="Zabbix API Python interface",
     long_description=long_description,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,7 @@ class TestPyZabbix(unittest.TestCase):
             }),
         )
 
-        zapi = ZabbixAPI('http://example.com')
+        zapi = ZabbixAPI('http://example.com', detect_version=False)
         zapi.login('mylogin', 'mypass')
 
         # Check request
@@ -56,7 +56,7 @@ class TestPyZabbix(unittest.TestCase):
             }),
         )
 
-        zapi = ZabbixAPI('http://example.com')
+        zapi = ZabbixAPI('http://example.com', detect_version=False)
         zapi.auth = "123"
         result = zapi.host.get()
 
@@ -92,7 +92,7 @@ class TestPyZabbix(unittest.TestCase):
             }),
         )
 
-        zapi = ZabbixAPI('http://example.com')
+        zapi = ZabbixAPI('http://example.com', detect_version=False)
         zapi.auth = "123"
         result = zapi.host.delete("22982", "22986")
 
@@ -124,7 +124,7 @@ class TestPyZabbix(unittest.TestCase):
             }),
         )
 
-        with ZabbixAPI('http://example.com') as zapi:
+        with ZabbixAPI('http://example.com', detect_version=False) as zapi:
             zapi.login('mylogin', 'mypass')
             self.assertEqual(zapi.auth, "0424bd59b807674191e7d77572075f33")
 
@@ -142,4 +142,4 @@ class TestPyZabbix(unittest.TestCase):
 
         zapi_detect = ZabbixAPI('http://example.com')
         self.assertEqual(zapi_detect.api_version(), '4.0.0')
-        self.assertEqual(zapi_detect._version, semantic_version.Version('4.0.0'))
+        self.assertEqual(zapi_detect.version, semantic_version.Version('4.0.0'))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import unittest
 import httpretty
 import json
 from pyzabbix import ZabbixAPI
+import semantic_version
 
 
 class TestPyZabbix(unittest.TestCase):
@@ -127,3 +128,18 @@ class TestPyZabbix(unittest.TestCase):
             zapi.login('mylogin', 'mypass')
             self.assertEqual(zapi.auth, "0424bd59b807674191e7d77572075f33")
 
+    @httpretty.activate
+    def test_detecting_version(self):
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://example.com/api_jsonrpc.php",
+            body=json.dumps({
+                "jsonrpc": "2.0",
+                "result": "4.0.0",
+                "id": 0
+            }),
+        )
+
+        zapi_detect = ZabbixAPI('http://example.com')
+        self.assertEqual(zapi_detect.api_version(), '4.0.0')
+        self.assertEqual(zapi_detect._version, semantic_version.Version('4.0.0'))


### PR DESCRIPTION
Zabbix 5.4 [introduces some changes](https://www.zabbix.com/documentation/5.4/manual/api/changes_5.2_-_5.4#user) in user authentication that need to be accounted for.

As specified in the changelog, the field `user` will be renamed to `username`, what will make this package unusable once 5.4 rolls out, hence this PR.

I also believe updating to Zabbix 5.4 should not break user scripts, that's why version autodetecting is in place.