### PR TITLE
Move detecting API version to login method

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -68,11 +68,7 @@ class ZabbixAPI(object):
         logger.info("JSON-RPC Server Endpoint: %s", self.url)
 
         self.version = ''
-        if detect_version:
-            self.version = semantic_version.Version(
-                self.api_version()
-            )
-            logger.info("Zabbix API version is: %s", self.api_version())
+        self._detect_version = detect_version
 
     def __enter__(self):
         return self
@@ -92,6 +88,12 @@ class ZabbixAPI(object):
            :param user: Username used to login into Zabbix
            :param api_token: API Token to authenticate with
         """
+
+        if self._detect_version:
+            self.version = semantic_version.Version(
+                self.api_version()
+            )
+            logger.info("Zabbix API version is: %s", self.api_version())
 
         # If the API token is explicitly provided, use this instead.
         if api_token is not None:

--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -43,6 +43,7 @@ class ZabbixAPI(object):
             session: optional pre-configured requests.Session instance
             use_authenticate: Use old (Zabbix 1.8) style authentication
             timeout: optional connect and read timeout in seconds, default: None (if you're using Requests >= 2.4 you can set it as tuple: "(connect, read)" which is used to set individual connect and read timeouts.)
+            detect_version: autodetect Zabbix API version
         """
 
         if session:

--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -94,7 +94,7 @@ class ZabbixAPI(object):
             self.version = semantic_version.Version(
                 self.api_version()
             )
-            logger.info("Zabbix API version is: %s", self.api_version())
+            logger.info("Zabbix API version is: %s", str(self.version))
 
         # If the API token is explicitly provided, use this instead.
         if api_token is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -142,4 +142,3 @@ class TestPyZabbix(unittest.TestCase):
 
         zapi_detect = ZabbixAPI('http://example.com')
         self.assertEqual(zapi_detect.api_version(), '4.0.0')
-        self.assertEqual(zapi_detect.version, semantic_version.Version('4.0.0'))


### PR DESCRIPTION
As it stands now, a API call is being made in `__init__` of ZabbixAPI class.

This is not ideal as some might want to modify the session object after object creation to make it ignore invalid certificates, for example.

Without this PR, this scenario will simply not work, as the call to `api_version` is done before modifying the session object.
```
zapi = ZabbixAPI('http://localhost')
zapi.session.verify = False
```

