### PR TITLE
fix: API object/method attributes are private

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -274,25 +274,25 @@ class ZabbixAPI:
 # pylint: disable=too-few-public-methods
 class ZabbixAPIMethod:
     def __init__(self, method: str, parent: ZabbixAPI):
-        self.method = method
-        self.parent = parent
+        self._method = method
+        self._parent = parent
 
     def __call__(self, *args, **kwargs):
         if args and kwargs:
             raise TypeError("Found both args and kwargs")
 
-        return self.parent.do_request(self.method, args or kwargs)["result"]
+        return self._parent.do_request(self._method, args or kwargs)["result"]
 
 
 # pylint: disable=too-few-public-methods
 class ZabbixAPIObject:
     def __init__(self, name: str, parent: ZabbixAPI):
-        self.name = name
-        self.parent = parent
+        self._name = name
+        self._parent = parent
 
     def _method(self, attr: str) -> ZabbixAPIMethod:
         """Dynamically create a method (ie: get)"""
-        return ZabbixAPIMethod(f"{self.name}.{attr}", self.parent)
+        return ZabbixAPIMethod(f"{self._name}.{attr}", self._parent)
 
     def __getattr__(self, attr: str) -> ZabbixAPIMethod:
         return self._method(attr)


### PR DESCRIPTION
In both `ZabbixAPIObject` and `ZabbixAPIMethod` classes, the `name`, `parent` and `method`, `parent` attributes are now private. Please do not rely on these internal attributes.

@lukecyca This could be considered as a breaking change, but I see that ZabbixAPIObject was never documented for the public and is not supposed to be used. So I wonder if it is safe to make those attributes privates as they should be ?