### PR TITLE
feat: parse version using packaging.version

### DIFF
--- a/pyzabbix/_api.py
+++ b/pyzabbix/_api.py
@@ -1,10 +1,12 @@
+# pylint: disable=wrong-import-order
+
 import logging
 from typing import Mapping, Optional, Sequence, Tuple, Union
 from warnings import warn
 
+from packaging.version import Version
 from requests import Session
 from requests.exceptions import JSONDecodeError
-from semantic_version import Version  # type: ignore
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -75,7 +77,7 @@ class ZabbixAPI:
         self.url = server
         logger.info(f"JSON-RPC Server Endpoint: {self.url}")
 
-        self.version = ""
+        self.version: Optional[Version] = None
         self._detect_version = detect_version
 
     def __enter__(self) -> "ZabbixAPI":

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "requests>=1.0",
-        "semantic-version>=2.8",
+        "packaging",
     ],
     extras_require={
         "dev": [

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -75,6 +75,8 @@ def test_login_with_context(requests_mock):
         ("4.0.0"),
         ("5.4.0"),
         ("6.2.0"),
+        ("6.2.0beta1"),
+        ("6.2.2alpha1"),
     ],
 )
 def test_login_with_version_detect(requests_mock, version):
@@ -166,18 +168,29 @@ def test_attr_syntax_args_and_kwargs_raises():
         zapi.host.delete("22982", hostids=5)
 
 
-def test_detecting_version(requests_mock):
+@pytest.mark.parametrize(
+    "version",
+    [
+        ("4.0.0"),
+        ("4.0.0rc1"),
+        ("6.2.0beta1"),
+        ("6.2.2alpha1"),
+    ],
+)
+def test_detecting_version(requests_mock, version):
     _zabbix_requests_mock_factory(
         requests_mock,
         json={
             "jsonrpc": "2.0",
-            "result": "4.0.0",
+            "result": version,
             "id": 0,
         },
     )
 
     zapi = ZabbixAPI("http://example.com")
-    assert zapi.api_version() == "4.0.0"
+    zapi.login("mylogin", "mypass")
+
+    assert zapi.api_version() == version
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Remove semantic-version dependency and use packaging.version to
parse Zabbix version. Based on the zabbix source code tags, the
version format seem to be PEP440 and parsing alpha|beta|rc versions
fail using semantic-version.