### PR TITLE
fix: catch ValueError during json parsing

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -6,7 +6,6 @@ from warnings import warn
 
 from packaging.version import Version
 from requests import Session
-from requests.exceptions import JSONDecodeError
 
 __all__ = [
     "ZabbixAPI",
@@ -218,7 +217,7 @@ class ZabbixAPI:
 
         try:
             response = resp.json()
-        except JSONDecodeError as exception:
+        except ValueError as exception:
             raise ZabbixAPIException(
                 f"Unable to parse json: {resp.text}"
             ) from exception


### PR DESCRIPTION
Only recent versions of requests have the JSONDecodeError exceptions.

https://github.com/psf/requests/issues/5794
https://requests.readthedocs.io/en/latest/community/updates/?highlight=JSONDecodeError#id4