### PR TITLE
Add a conservative default connect/read timeout

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -51,14 +51,14 @@ class ZabbixAPI:
         server: str = "http://localhost/zabbix",
         session: Optional[Session] = None,
         use_authenticate: bool = False,
-        timeout: Optional[Union[float, int, Tuple[int, int]]] = None,
+        timeout: Optional[Union[float, int, Tuple[int, int]]] = 30,
         detect_version: bool = True,
     ):
         """
         :param server: Base URI for zabbix web interface (omitting /api_jsonrpc.php)
         :param session: optional pre-configured requests.Session instance
         :param use_authenticate: Use old (Zabbix 1.8) style authentication
-        :param timeout: optional connect and read timeout in seconds, default: None
+        :param timeout: optional connect and read timeout in seconds, default: 30
                         If you're using Requests >= 2.4 you can set it as
                         tuple: "(connect, read)" which is used to set individual
                         connect and read timeouts.


### PR DESCRIPTION
I've experienced that the Zabbix API sometimes hang. I believe this is due to some database related issues (hang on write operations only).

If someone encounter this problem a script using pyzabbix might hang forever if you forget to add a timeout parameter:

https://github.com/lukecyca/pyzabbix/blob/962693d88a7cb3c53aeb0b7d62fc7198921abca8/pyzabbix/api.py#L61-L64

The [requests quickstart](https://docs.python-requests.org/en/latest/user/quickstart/#timeouts) says the following about the `timeout` parameter:

> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely

Following this guide I think that pyzabbix should have some kind of default, rather than `None`.

Also quoting from the quickstart:

> timeout is not a time limit on the entire response download; rather, an exception is raised if the server has not issued a response for timeout seconds (more precisely, if no bytes have been received on the underlying socket for timeout seconds). If no timeout is specified explicitly, requests do not time out.

I think that a timeout of 30 seconds will be a very, very conservative default, but it should prevent that someone that forget to set a timeout encounter scripts that hang for ever.