### PR TITLE
feat: fix do_request overwriting headers

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -216,7 +216,7 @@ class ZabbixAPI:
         resp = self.session.post(
             self.url,
             json=payload,
-            headers=headers,
+            headers={**self.session.headers, **headers},
             timeout=self.timeout,
         )
         logger.debug("Response Code: %s", resp.status_code)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -217,9 +217,11 @@ def test_error_response(requests_mock, data):
 
     with pytest.raises(
         ZabbixAPIException,
-        match="Error -32602: Invalid params., No data."
-        if data is None
-        else f"Error -32602: Invalid params., {data}",
+        match=(
+            "Error -32602: Invalid params., No data."
+            if data is None
+            else f"Error -32602: Invalid params., {data}"
+        ),
     ):
         zapi = ZabbixAPI("http://example.com")
         zapi.host.get()


### PR DESCRIPTION
Currently, the headers send in do_request method are set to either be empty (no headers are being sent) or just the 'Authorization' or 'auth' header.
Zabbix requires the 'Content-Type' header: 

> The request must have the Content-Type header set to one of these values: application/json-rpc, application/json or application/jsonrequest.
https://www.zabbix.com/documentation/current/en/manual/api

And this header was being included in the default session headers, but inside the do_request method the session headers are getting unintentionally overwritten by headers dict that is initialized to being empty:
`        headers = {}`
and later modified to include either 'Authorization' or 'auth':
`            if self.version and self.version >= ZABBIX_6_4_0:
                headers["Authorization"] = f"Bearer {self.auth}"
            else:
                payload["auth"] = self.auth`
after which we are making the request and unintentionally overwriting the default headers in post method parameter's:
`        resp = self.session.post(
            self.url,
            json=payload,
            headers=headers,
            timeout=self.timeout,
        )`
Resulting with empty headers or not enough headers being sent.

To address this issue, my change ensures that the default headers are preserved while also incorporating the additional headers created in the do_request method.