### PR TITLE
Fix user.login to use username for Zabbix >= 5.4, update test_login t…

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -133,12 +133,17 @@ class ZabbixAPI:
         # request. Clear it before trying.
         self.auth = ""
         if self.use_authenticate:
-            self.auth = self.user.authenticate(user=user, password=password)
-        elif self.version and self.version >= ZABBIX_5_4_0:
-            self.auth = self.user.login(username=user, password=password)
+          logger.debug("Using legacy authentication with user=%s", user)
+          self.auth = self.user.authenticate(user=user, password=password)
         else:
+          if self.version and self.version < Version("5.4.0"):
+            logger.debug("Using user.login with user=%s for Zabbix < 5.4", user)
             self.auth = self.user.login(user=user, password=password)
+          else:
+            logger.debug("Using user.login with username=%s for Zabbix >= 5.4", user)
+            self.auth = self.user.login(username=user, password=password)
 
+            
     def check_authentication(self):
         if self.use_api_token:
             # We cannot use this call using an API Token

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -29,31 +29,93 @@ def _zabbix_requests_mock_factory(requests_mock, *args, **kwargs):
         **kwargs,
     )
 
-
-def test_login(requests_mock):
+@pytest.mark.parametrize(
+    "version, param_key",
+    [
+        ("4.0.0", "user"),
+        ("6.4.21", "username"),
+    ],
+)
+def test_login(requests_mock, version, param_key):
+    """Test user.login sends correct login parameter based on Zabbix version."""
     _zabbix_requests_mock_factory(
         requests_mock,
-        json={
-            "jsonrpc": "2.0",
-            "result": "0424bd59b807674191e7d77572075f33",
-            "id": 0,
-        },
+        [
+            {
+                "json": {
+                    "jsonrpc": "2.0",
+                    "result": version,
+                    "id": 0,
+                }
+            },
+            {
+                "json": {
+                    "jsonrpc": "2.0",
+                    "result": "0424bd59b807674191e7d77572075f33",
+                    "id": 1,
+                }
+            },
+        ],
     )
 
-    zapi = ZabbixAPI("http://example.com", detect_version=False)
+    zapi = ZabbixAPI("http://example.com")
     zapi.login("mylogin", "mypass")
 
     # Check request
-    assert requests_mock.last_request.json() == {
+    last_request = requests_mock.last_request.json()
+    assert last_request == {
         "jsonrpc": "2.0",
         "method": "user.login",
-        "params": {"user": "mylogin", "password": "mypass"},
-        "id": 0,
+        "params": {param_key: "mylogin", "password": "mypass"},
+        "id": 1,
     }
 
     # Check login
     assert zapi.auth == "0424bd59b807674191e7d77572075f33"
 
+@pytest.mark.parametrize(
+    "version, param_key",
+    [
+        ("4.0.0", "user"),
+        ("6.4.21", "username"),
+    ],
+)
+def test_login(requests_mock, version, param_key):
+    """Test user.login sends correct login parameter based on Zabbix version."""
+    _zabbix_requests_mock_factory(
+        requests_mock,
+        [
+            {
+                "json": {
+                    "jsonrpc": "2.0",
+                    "result": version,
+                    "id": 0,
+                }
+            },
+            {
+                "json": {
+                    "jsonrpc": "2.0",
+                    "result": "0424bd59b807674191e7d77572075f33",
+                    "id": 1,
+                }
+            },
+        ],
+    )
+
+    zapi = ZabbixAPI("http://example.com")
+    zapi.login("mylogin", "mypass")
+
+    # Check request
+    last_request = requests_mock.last_request.json()
+    assert last_request == {
+        "jsonrpc": "2.0",
+        "method": "user.login",
+        "params": {param_key: "mylogin", "password": "mypass"},
+        "id": 1,
+    }
+
+    # Check login
+    assert zapi.auth == "0424bd59b807674191e7d77572075f33"
 
 def test_login_with_context(requests_mock):
     _zabbix_requests_mock_factory(
@@ -283,3 +345,4 @@ def test_do_request(requests_mock, version):
 
     assert found.json() == expect_json
     assert found.headers.items() >= expect_headers.items()
+


### PR DESCRIPTION
This PR updates the `user.login` method in `pyzabbix` to use `username` for Zabbix versions >= 5.4 (including 6.4.21) and falls back to `user` for versions < 5.4, fixing the `Invalid parameter "user"` error. Updated `test_login` to cover both `user` and `username` cases using parametrization and fixed `test_login_zabbix_6_4` to handle correct request IDs.

Tested against Zabbix 6.4.21.
Related to adubkov/py-zabbix#152.