### PR TITLE
feat: drop support for python < 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,4 +50,4 @@ repos:
     rev: v3.9.0
     hooks:
       - id: pyupgrade
-        args: [--py3-plus, --py36-plus]
+        args: [--py3-plus, --py39-plus]

--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -1,7 +1,8 @@
 # pylint: disable=wrong-import-order
 
 import logging
-from typing import Mapping, Optional, Sequence, Tuple, Union
+from collections.abc import Mapping, Sequence
+from typing import Optional, Union
 from warnings import warn
 
 from packaging.version import Version
@@ -51,7 +52,7 @@ class ZabbixAPI:
         server: str = "http://localhost/zabbix",
         session: Optional[Session] = None,
         use_authenticate: bool = False,
-        timeout: Optional[Union[float, int, Tuple[int, int]]] = None,
+        timeout: Optional[Union[float, int, tuple[int, int]]] = None,
         detect_version: bool = True,
     ):
         """

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,11 @@ setup(
     url="http://github.com/lukecyca/pyzabbix",
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
@@ -32,7 +31,7 @@ setup(
     ],
     packages=["pyzabbix"],
     package_data={"": ["py.typed"]},
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     install_requires=[
         "requests>=1.0",
         "packaging",


### PR DESCRIPTION
Python versions < 3.9 are EOL: https://devguide.python.org/versions/